### PR TITLE
自动深色模式增加statusAlpha的支持，修复一个bug

### DIFF
--- a/barlibrary/src/main/java/com/gyf/barlibrary/BarParams.java
+++ b/barlibrary/src/main/java/com/gyf/barlibrary/BarParams.java
@@ -76,6 +76,13 @@ public class BarParams implements Cloneable {
     boolean autoDarkModeEnable = false;
 
     /**
+     * 自动深色模式的状态栏透明度
+     * Status bar transparency in automatic dark mode.
+     */
+    @FloatRange(from = 0f, to = 1f)
+    float autoDarkModeStatusBarAlpha = 0.0f;
+
+    /**
      * 是否可以修改状态栏颜色
      * The Status bar flag.
      */

--- a/barlibrary/src/main/java/com/gyf/barlibrary/ImmersionBar.java
+++ b/barlibrary/src/main/java/com/gyf/barlibrary/ImmersionBar.java
@@ -1052,7 +1052,19 @@ public class ImmersionBar {
      * @return the immersion bar
      */
     public ImmersionBar autoDarkModeEnable(boolean isEnable) {
+        return autoDarkModeEnable(isEnable, 0f);
+    }
+
+    /**
+     * 是否启用 自动根据StatusBar和NavigationBar颜色调整深色模式与亮色模式，判断设备支不支持状态栏变色来设置状态栏透明度
+     *
+     * @param isEnable    true启用 默认false
+     * @param statusAlpha the status alpha 如果不支持状态栏字体变色可以使用statusAlpha来指定状态栏透明度，比如白色状态栏的时候可以用到
+     * @return the immersion bar
+     */
+    public ImmersionBar autoDarkModeEnable(boolean isEnable, @FloatRange(from = 0f, to = 1f) float statusAlpha) {
         mBarParams.autoDarkModeEnable = isEnable;
+        mBarParams.autoDarkModeStatusBarAlpha = statusAlpha;
         return this;
     }
 
@@ -1838,8 +1850,12 @@ public class ImmersionBar {
     private void adjustDarkModeParams() {
         if (mBarParams.autoDarkModeEnable) {
             int boundaryColor = 0xFFBABABA;
-            statusBarDarkFont(mBarParams.statusBarColor != Color.TRANSPARENT && mBarParams.statusBarColor > boundaryColor);
-            navigationBarDarkIcon(mBarParams.navigationBarColor != Color.TRANSPARENT && mBarParams.navigationBarColor > boundaryColor);
+            if (mBarParams.statusBarColor != Color.TRANSPARENT) {
+                statusBarDarkFont(mBarParams.statusBarColor > boundaryColor, mBarParams.autoDarkModeStatusBarAlpha);
+            }
+            if (mBarParams.navigationBarColor != Color.TRANSPARENT) {
+                navigationBarDarkIcon(mBarParams.navigationBarColor > boundaryColor, mBarParams.autoDarkModeStatusBarAlpha);
+            }
         }
     }
 


### PR DESCRIPTION
1.自动深色模式增加statusAlpha的支持
```
.autoDarkModeEnable(true)
.autoDarkModeEnable(true, 0.2f)
```

2.修复statusBarColor是透明色时，开启自动深色模式会导致手动调用statusBarDarkFont失效的问题.

透明状态栏的字体色应该由用户手动控制，所以不自动判断该用深色还是亮色